### PR TITLE
Lang stats

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ filterwarnings =
     ignore::sqlalchemy.exc.SAWarning
 addopts =
     --cov
-mock_use_standalone_module = true
+mock_use_standalone_module = false
 
 [coverage:run]
 source =

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ filterwarnings =
     ignore::sqlalchemy.exc.SAWarning
 addopts =
     --cov
-mock_use_standalone_module = false
 
 [coverage:run]
 source =

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
             'twine',
         ],
         'test': [
-            'mock',
             'pytest>=3.6',
             'pytest-mock',
             'pytest-cov',

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ setup(
             'twine',
         ],
         'test': [
-            'pytest>=3.6',
-            'pytest-mock',
+            'pytest>=5.0',
             'pytest-cov',
             'coverage>=4.2',
         ],

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         'unidecode',
         'zope.component',
         'zope.interface',
+        'pybtex<0.23; python_version < "3.6"',
+        'pybtex; python_version > "3.5"',
     ],
     extras_require={
         'dev': [
@@ -47,6 +49,7 @@ setup(
         'test': [
             'pytest>=5.0',
             'pytest-cov',
+            'pytest-mock',
             'coverage>=4.2',
         ],
     },

--- a/src/pyclics/commands/colexification.py
+++ b/src/pyclics/commands/colexification.py
@@ -8,29 +8,31 @@ from collections import defaultdict
 import networkx as nx
 from clldutils.clilib import Table, add_format
 
+
 def register(parser):
-    add_format(parser, default='simple')
+    add_format(parser, default="simple")
     parser.add_argument(
-        '--show',
+        "--show",
         help="Number of most common colexifications to display after computation",
         type=int,
-        default=10)
+        default=10,
+    )
 
 
 def run(args):
     args.repos._log = args.log
 
     def clean(word):
-        return ''.join([w for w in word if w not in '/,;"'])
+        return "".join([w for w in word if w not in '/,;"'])
 
     varieties = args.repos.db.varieties
 
-    args.log.info('Adding nodes to the graph')
+    args.log.info("Adding nodes to the graph")
     G = nx.Graph()
     for concept in args.repos.db.iter_concepts():
         G.add_node(concept.id, **concept.as_node_attrs())
 
-    args.log.info('Adding edges to the graph')
+    args.log.info("Adding edges to the graph")
     for v_, formA, formB in args.repos.iter_colexifications(varieties):
         if not G[formA.concepticon_id].get(formB.concepticon_id, False):
             G.add_edge(
@@ -42,96 +44,162 @@ def run(args):
                 wofam=[],
             )
 
-        G[formA.concepticon_id][formB.concepticon_id]['words'].add(
-            (formA.gid, formB.gid))
-        G[formA.concepticon_id][formB.concepticon_id]['languages'].add(v_.gid)
-        G[formA.concepticon_id][formB.concepticon_id]['families'].add(v_.family)
-        G[formA.concepticon_id][formB.concepticon_id]['wofam'].append('/'.join([
-            formA.gid,
-            formB.gid,
-            formA.clics_form,
-            v_.gid,
-            v_.family,
-            clean(formA.form),
-            clean(formB.form)]))
+        G[formA.concepticon_id][formB.concepticon_id]["words"].add(
+            (formA.gid, formB.gid)
+        )
+        G[formA.concepticon_id][formB.concepticon_id]["languages"].add(v_.gid)
+        G[formA.concepticon_id][formB.concepticon_id]["families"].add(v_.family)
+        G[formA.concepticon_id][formB.concepticon_id]["wofam"].append(
+            "/".join(
+                [
+                    formA.gid,
+                    formB.gid,
+                    formA.clics_form,
+                    v_.gid,
+                    v_.family,
+                    clean(formA.form),
+                    clean(formB.form),
+                ]
+            )
+        )
 
     # Build map of variety name to Glottocode, for per-language output
     lang_map = {
-       '%s-%s' % (dataset_id, lang_id) : glottocode
-        for dataset_id, lang_id, glottocode in
-        args.repos.db.fetchall("SELECT dataset_ID, ID, Glottocode FROM languagetable")
+        "%s-%s" % (dataset_id, lang_id): glottocode
+        for dataset_id, lang_id, glottocode in args.repos.db.fetchall(
+            "SELECT dataset_ID, ID, Glottocode FROM languagetable"
+        )
     }
 
     # Collect lists of concepts for each language variety, so that we can check if a colexification would be
     # possible in it (i.e., if there is enough data)
     concepts = defaultdict(set)
-    for dataset_id, lang_id, concepticon_id in args.repos.db.fetchall("""
+    for dataset_id, lang_id, concepticon_id in args.repos.db.fetchall(
+        """
         SELECT f.dataset_ID, f.Language_ID, p.Concepticon_ID
         FROM formtable AS f, parametertable AS P
-        WHERE f.Parameter_ID = p.ID AND f.dataset_ID = p.dataset_ID"""):
+        WHERE f.Parameter_ID = p.ID AND f.dataset_ID = p.dataset_ID"""
+    ):
         concepts["%s-%s" % (dataset_id, lang_id)].add(concepticon_id)
 
     # Iterate over all edges and collect data
-    counts = defaultdict(int)
-    possible = defaultdict(int)
+    all_counts, threshold_counts = defaultdict(int), defaultdict(int)
+    all_possible, threshold_possible = defaultdict(int), defaultdict(int)
+    colex2lang = defaultdict(set)
     for concept_a, concept_b, data in G.edges(data=True):
+        # Collect concept2languages info (Ezequiel Koile's request)
+        for lang, glottocode in lang_map.items():
+            if lang in data["languages"]:
+                colex2lang[concept_a, concept_b].add(glottocode)
+
+        # Collect language colexification affinity (David Gil's request)
         # Don't consider the edge if we don't have at least one language in it
-        if not data['languages']:
+        if not data["languages"]:
             continue
+
+        # Check if the current concept pair passes the threshold filter
+        filter_family, filter_lang, filter_words = True, True, True
+        if args.edgefilter == "families":
+            filter_family = len(data["families"]) >= args.threshold
+        if args.edgefilter == "languages":
+            filter_lang = len(data["languages"]) >= args.threshold
+        if args.edgefilter == "words":
+            filter_words = len(data["words"]) >= args.threshold
+        pass_filter = all([filter_family, filter_lang, filter_words])
 
         # Inspect all languages
         for lang in lang_map:
-            if lang in data['languages']:
-                counts[lang] += 1
-                possible[lang] += 1
+            if lang in data["languages"]:
+                all_counts[lang] += 1
+                all_possible[lang] += 1
+                if pass_filter:
+                    threshold_counts[lang] += 1
+                    threshold_possible[lang] += 1
             else:
                 if concept_a in concepts[lang] and concept_b in concepts[lang]:
-                    possible[lang] += 1
+                    all_possible[lang] += 1
+                    if pass_filter:
+                        threshold_possible[lang] += 1
 
-    # Output per-language info
-    with open("per_language.tsv", 'w') as tsvfile:
-        writer = csv.DictWriter(tsvfile, delimiter="\t", fieldnames=['LANG_KEY', 'GLOTTOCODE', 'COLEXIFICATIONS', 'POTENTIAL'])
+    # Output colex2lang info (Ezequiel Koile request)
+    with open("colex2lang.tsv", "w") as tsvfile:
+        tsvfile.write("CONCEPT_A\tCONCEPT_B\tGLOTTOCODES\n")
+        for entry, langs in colex2lang.items():
+            tsvfile.write("%s\t%s\t%s\n" % (entry[0], entry[1], ",".join(langs)))
+
+    # Output per-language info (David Gil request)
+    with open("per_language.tsv", "w") as tsvfile:
+        writer = csv.DictWriter(
+            tsvfile,
+            delimiter="\t",
+            fieldnames=[
+                "LANG_KEY",
+                "GLOTTOCODE",
+                "COLEXIFICATIONS_ALL",
+                "POTENTIAL_ALL",
+                "COLEXIFICATIONS_THRESHOLD",
+                "POTENTIAL_THRESHOLD",
+            ],
+        )
         writer.writeheader()
         for lang in sorted(lang_map):
-            writer.writerow({
-                'LANG_KEY' : lang,
-                'GLOTTOCODE' : lang_map[lang],
-                'COLEXIFICATIONS' : counts[lang],
-                'POTENTIAL' : possible[lang]
-                })
+            writer.writerow(
+                {
+                    "LANG_KEY": lang,
+                    "GLOTTOCODE": lang_map[lang],
+                    "COLEXIFICATIONS_ALL": all_counts[lang],
+                    "POTENTIAL_ALL": all_possible[lang],
+                    "COLEXIFICATIONS_THRESHOLD": threshold_counts[lang],
+                    "POTENTIAL_THRESHOLD": threshold_possible[lang],
+                }
+            )
 
     edges = {}
     for edgeA, edgeB, data in G.edges(data=True):
-        edges[edgeA, edgeB] = (len(data['families']), len(data['languages']), len(data['words']))
+        edges[edgeA, edgeB] = (
+            len(data["families"]),
+            len(data["languages"]),
+            len(data["words"]),
+        )
 
     ignore_edges = []
     for edgeA, edgeB, data in G.edges(data=True):
-        data['WordWeight'] = len(data['words'])
-        data['words'] = ';'.join(sorted(['{0}/{1}'.format(x, y) for x, y in data['words']]))
-        data['FamilyWeight'] = len(data['families'])
-        data['families'] = ';'.join(sorted(data['families']))
-        data['LanguageWeight'] = len(data['languages'])
-        data['languages'] = ';'.join(data['languages'])
-        data['wofam'] = ';'.join(data['wofam'])
-        if args.edgefilter == 'families' and data['FamilyWeight'] < args.threshold:
+        data["WordWeight"] = len(data["words"])
+        data["words"] = ";".join(
+            sorted(["{0}/{1}".format(x, y) for x, y in data["words"]])
+        )
+        data["FamilyWeight"] = len(data["families"])
+        data["families"] = ";".join(sorted(data["families"]))
+        data["LanguageWeight"] = len(data["languages"])
+        data["languages"] = ";".join(data["languages"])
+        data["wofam"] = ";".join(data["wofam"])
+        if args.edgefilter == "families" and data["FamilyWeight"] < args.threshold:
             ignore_edges.append((edgeA, edgeB))
-        elif args.edgefilter == 'languages' and data['LanguageWeight'] < args.threshold:
+        elif args.edgefilter == "languages" and data["LanguageWeight"] < args.threshold:
             ignore_edges.append((edgeA, edgeB))
-        elif args.edgefilter == 'words' and data['WordWeight'] < args.threshold:
+        elif args.edgefilter == "words" and data["WordWeight"] < args.threshold:
             ignore_edges.append((edgeA, edgeB))
 
     G.remove_edges_from(ignore_edges)
 
-    nodenames = {r[0]: r[1] for r in args.repos.db.fetchall(
-        "select distinct concepticon_id, concepticon_gloss from parametertable")}
+    nodenames = {
+        r[0]: r[1]
+        for r in args.repos.db.fetchall(
+            "select distinct concepticon_id, concepticon_gloss from parametertable"
+        )
+    }
 
     with Table(
-        args, 'ID A', 'Concept A', 'ID B', 'Concept B', 'Families', 'Languages', 'Words'
+        args, "ID A", "Concept A", "ID B", "Concept B", "Families", "Languages", "Words"
     ) as table:
         count = 0
-        for (nodeA, nodeB), (fc, lc, wc) in sorted(edges.items(), key=lambda i: i[1], reverse=True):
+        for (nodeA, nodeB), (fc, lc, wc) in sorted(
+            edges.items(), key=lambda i: i[1], reverse=True
+        ):
             if (nodeA, nodeB) not in ignore_edges:
-                table.append([nodeA, nodenames[nodeA], nodeB, nodenames[nodeB], fc, lc, wc])
+                table.append(
+                    [nodeA, nodenames[nodeA], nodeB, nodenames[nodeB], fc, lc, wc]
+                )
                 count += 1
             if count >= args.show:
                 break


### PR DESCRIPTION
This PR adds code for collecting and writing data related to (a) which languages colexify which pair of concepts and (b) the absolute number of actual and potential colexifications for each language.

It is related to the two requests regarding clics in the last weeks, which we will discuss in a post for the CALC blog. I have kept the code in the same function, which is rather large now; I can move it into a separate function of course. While this could technically be an independent command, it requires the edge processing performed by `colexification`, so I decided to extend it. Note that the information is not collected if the user does not explicitly request it (by providing output file names).